### PR TITLE
Update ActivityLogger.php to include own description when using API / Crawler

### DIFF
--- a/src/App/Http/Traits/ActivityLogger.php
+++ b/src/App/Http/Traits/ActivityLogger.php
@@ -30,7 +30,9 @@ trait ActivityLogger
 
         if (Crawler::isCrawler()) {
             $userType = trans('LaravelLogger::laravel-logger.userTypes.crawler');
-            $description = $userType.' '.trans('LaravelLogger::laravel-logger.verbTypes.crawled').' '.Request::fullUrl();
+            if(is_null($description)){
+                $description = $userType.' '.trans('LaravelLogger::laravel-logger.verbTypes.crawled').' '.Request::fullUrl();
+            }
         }
 
         if (!$description) {

--- a/src/App/Http/Traits/ActivityLogger.php
+++ b/src/App/Http/Traits/ActivityLogger.php
@@ -30,7 +30,7 @@ trait ActivityLogger
 
         if (Crawler::isCrawler()) {
             $userType = trans('LaravelLogger::laravel-logger.userTypes.crawler');
-            if(is_null($description)){
+            if(is_null($description)) {
                 $description = $userType.' '.trans('LaravelLogger::laravel-logger.verbTypes.crawled').' '.Request::fullUrl();
             }
         }

--- a/src/App/Http/Traits/ActivityLogger.php
+++ b/src/App/Http/Traits/ActivityLogger.php
@@ -30,7 +30,7 @@ trait ActivityLogger
 
         if (Crawler::isCrawler()) {
             $userType = trans('LaravelLogger::laravel-logger.userTypes.crawler');
-            if(is_null($description)) {
+            if (is_null($description)) {
                 $description = $userType.' '.trans('LaravelLogger::laravel-logger.verbTypes.crawled').' '.Request::fullUrl();
             }
         }


### PR DESCRIPTION
Only use the default crawler description if none is provided. At the moment, if a Guzzle / Get request is made by a controller there is no way to provide your own description using ActivityLogger::activity('my description'); as it defaults to the crawler description.